### PR TITLE
Add example for AssumeRoleTokenProvider option

### DIFF
--- a/doc_source/sessions.rst
+++ b/doc_source/sessions.rst
@@ -146,6 +146,13 @@ when you want to provide the config profile, or override the shared config state
         SharedConfigState: SharedConfigEnable,
     })
 
+    // Assume an IAM role with MFA promting for token code on stdin.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+        AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+        SharedConfigState: SharedConfigEnable,
+    }))
+
+
 Deprecated ``New``
 ------------------
 


### PR DESCRIPTION
Adds an example for using the `AssumeRoleTokenProvider` option which was added in aws/aws-sdk-go#1088.