### PR TITLE
Correct AWS SDK for Go S3 CreateBucket example

### DIFF
--- a/doc_source/s3-example-creating-buckets.rst
+++ b/doc_source/s3-example-creating-buckets.rst
@@ -105,7 +105,7 @@ the
 bucket was created, and then notify the user of success.
 
 .. literalinclude:: example_code/s3/s3_create_bucket.go
-   :lines: 54-64
+   :lines: 46-64
 
 If an error does occur, print the error details and exit the routine.
 


### PR DESCRIPTION
Corrects the AWS SDK for Go's S3 CreateBucket example to show the full example of creating the bucket, in addition the the waiter.

Fix aws/aws-sdk-go#1148