### PR TITLE
Edits for meta descriptions, keywords, and code example titles 

### DIFF
--- a/doc_source/cb-example-build-project.rst
+++ b/doc_source/cb-example-build-project.rst
@@ -10,9 +10,14 @@
 
 .. _cb-example-build-project:
 
-##################
-Building a Project
-##################
+#################################
+Building an AWS CodeBuild Project
+#################################
+
+.. meta::
+    :description:
+        Build AWS CodeBuild projects using this AWS SDK for Go code example.
+    :keywords: AWS SDK for Go code examples, CodeBuild
 
 The following example builds the |ACBlong| project specified on the command line.
 If no command-line argument is supplied, it emits an error and quits.

--- a/doc_source/cb-example-list-builds.rst
+++ b/doc_source/cb-example-list-builds.rst
@@ -10,9 +10,14 @@
 
 .. _cb-example-list-builds:
 
-###########################
-Listing your Project Builds
-###########################
+#########################################
+Listing Your AWS CodeBuild Project Builds
+#########################################
+
+.. meta::
+    :description:
+        List AWS CodeBuild projects using this AWS SDK for Go code example.
+    :keywords: AWS SDK for Go code examples, CodeBuild
 
 The following example displays information about your |ACBlong| project builds,
 including the name of the project, when the build started, and how long each

--- a/doc_source/cb-example-list-projects.rst
+++ b/doc_source/cb-example-list-projects.rst
@@ -10,9 +10,14 @@
 
 .. _cb-example-list-projects:
 
-######################################
-Getting Information about All Projects
-######################################
+####################################################
+Getting Information about All AWS CodeBuild Projects
+####################################################
+
+.. meta::
+    :description:
+        Get information about AWS CodeBuild projects using this AWS SDK for Go code example.
+    :keywords: AWS SDK for Go code examples, CodeBuild
 
 The following example lists the names of up to 100 of your |ACBlong| projects.
 

--- a/doc_source/common-examples.rst
+++ b/doc_source/common-examples.rst
@@ -9,13 +9,13 @@
    limitations under the License.
 
 
-########################
+######################
 |sdk-go| Code Examples
-########################
+######################
 
 .. meta::
-   :description: Use AWS SDK for Go code examples to write your Go applications.
-   :keywords: examples
+   :description: Get examples of how to access AWS services using the AWS SDK for Go code examples.
+   :keywords: AWS SDK for Go code examples
 
 The |sdk-go| examples can help you write your own Go applications that use Amazon Web Services.
 The examples assume you have already set up and configured the SDK (that

--- a/doc_source/cw-example-describing-alarms.rst
+++ b/doc_source/cw-example-describing-alarms.rst
@@ -10,13 +10,13 @@
 
 .. _examples-cw-describe-alarms:
 
-########################################
-Describing |CW| Alarms with the |sdk-go|
-########################################
+######################
+Describing |CW| Alarms
+######################
 
 .. meta::
-   :description: Use this code example to learn how to describe alarms in Amazon Cloudwatch.
-   :keywords: AWS SDK for Go examples, CloudWatch, alarms
+   :description: Learn to describe alarms in Amazon Cloudwatch using the AWS SDK for Go.
+   :keywords: AWS SDK for Go code examples, CloudWatch, alarms
 
 This example shows you how to retrieve basic information that describes your |CW| alarms.
 
@@ -25,8 +25,8 @@ You can download complete versions of these example files from the
 
 .. _cw-describe-alarms-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 An alarm watches a single metric over a time period you specify. The alarm performs one or more actions
 based on the value of the metric relative to a given threshold over a number of time periods.

--- a/doc_source/cw-example-getting-metrics.rst
+++ b/doc_source/cw-example-getting-metrics.rst
@@ -10,13 +10,14 @@
 
 .. _examples-cw-getting-metrics:
 
-###########################################
-Getting Metrics from |CW| with the |sdk-go|
-###########################################
+#########################
+Getting Metrics from |CW|
+#########################
 
 .. meta::
-   :description: Use this code example to learn how to retrieve a list of published CloudWatch metrics and publish data points to CloudWatch metrics in Go.
-   :keywords: AWS SDK for Go examples, CloudWatch, alarm actions
+   :description: Retrieve a list of published CloudWatch metrics and publish data points to CloudWatch
+   metrics using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, CloudWatch, alarm actions
 
 These Go examples show you how to retrieve a list of published |CW| metrics and publish
 data points to |CW| metrics with the |sdk-go|, as follows:
@@ -29,8 +30,8 @@ You can download complete versions of these example files from the
 
 .. _cw-get-metrics-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 Metrics are data about the performance of your systems. You can enable detailed monitoring of
 some resources, such as your |EC2| instances, or your own application metrics.

--- a/doc_source/cw-example-sending-events.rst
+++ b/doc_source/cw-example-sending-events.rst
@@ -11,13 +11,13 @@
 
 .. _examples-cw-sending-events:
 
-#############################################
-Sending Events to |CWElong| with the |sdk-go|
-#############################################
+###########################
+Sending Events to |CWElong|
+###########################
 
 .. meta::
-   :description: Use this code example to learn how to work with the CloudWatch Events service in Go.
-   :keywords: AWS SDK for Go examples, CloudWatch Events, targets, rules
+   :description: Work with the CloudWatch Events service using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, CloudWatch Events, targets, rules
 
 
 These Go examples show you how to use the |sdk-go| to:
@@ -31,8 +31,8 @@ You can download complete versions of these example files from the
 
 .. _cw-get-sending-events-scenario:
 
-The Scenario
-=============
+Scenario
+========
 
 |CWE| delivers a near real-time stream of system events that describe changes in AWS resources
 to any of various targets. Using simple rules, you can match events and route them to one or more target

--- a/doc_source/cw-example-using-alarm-actions.rst
+++ b/doc_source/cw-example-using-alarm-actions.rst
@@ -10,13 +10,14 @@
 
 .. _examples-cw-alarms:
 
-########################################################
-Using Alarms and Alarm Actions in |CW| with the |sdk-go|
-########################################################
+######################################
+Using Alarms and Alarm Actions in |CW|
+######################################
 
 .. meta::
-   :description: Use this code example to learn how to create alarms and alarm actions to change the state of your EC2 instances in Amazon Cloudwatch.
-   :keywords: AWS SDK for Go examples, CloudWatch, alarm actions
+   :description: Create alarms and alarm actions to change the state of EC2 instances using
+   this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, CloudWatch, alarm actions
 
 These Go examples show you how to change the state of your |EC2| instances automatically based
 on a |CW| alarm, as follows:
@@ -29,8 +30,8 @@ You can download complete versions of these example files from the
 
 .. _cw-create-alarm-actions-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 You can use alarm actions to create alarms that automatically stop, terminate, reboot, or
 recover your |EC2| instances. You can use the stop or terminate actions when you no

--- a/doc_source/ec2-example-create-images.rst
+++ b/doc_source/ec2-example-create-images.rst
@@ -10,13 +10,14 @@
 
 .. _examples-ec2-tags-no-block:
 
-#############################################################################
-Creating |EC2| Instances with Tags or without Block Devices with the |sdk-go|
-#############################################################################
+###########################################################
+Creating |EC2| Instances with Tags or without Block Devices
+###########################################################
 
 .. meta::
-   :description: Use this code example to learn how to create Amazon EC2 instances with tags or no block devices.
-   :keywords: examples, EC2, tags, block device
+   :description: Create Amazon EC2 instances with tags or no block devices using this AWS SDK for Go code
+   example.
+   :keywords: AWS SDK for Go code examples, EC2, tags, block device
 
 
 This Go example shows you how to:
@@ -28,8 +29,8 @@ You can download complete versions of these example files from the
 
 .. _ec2-tags-scenario:
 
-The Scenarios
-=============
+Scenarios
+=========
 
 In these examples, you use a series of Go routines to create |EC2| instances
 with tags or set up an instance without a block device.

--- a/doc_source/ec2-example-elastic-ip-addresses.rst
+++ b/doc_source/ec2-example-elastic-ip-addresses.rst
@@ -10,13 +10,13 @@
 
 .. _examples-ec2-allocate-address:
 
-#####################################################
-Using Elastic IP Addresses in |EC2| with the |sdk-go|
-#####################################################
+###################################
+Using Elastic IP Addresses in |EC2|
+###################################
 
 .. meta::
-   :description: Use this code example to learn how to allocate Elastic IP addresses in Amazon EC2.
-   :keywords: AWS SDK for Go examples, Elastic IP addresses
+   :description: Allocate Elastic IP addresses in Amazon EC2 using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, Elastic IP addresses
 
 
 These Go examples show you how to:
@@ -30,8 +30,8 @@ You can download complete versions of these example files from the
 
 .. _ec-allocate-address-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 An Elastic IP address is a static IP address designed for dynamic cloud computing that is associated with
 your AWS account. It is a public IP address, reachable from

--- a/doc_source/ec2-example-manage-instances.rst
+++ b/doc_source/ec2-example-manage-instances.rst
@@ -10,13 +10,13 @@
 
 .. _examples-ec2-manage-instances:
 
-##########################################
-Managing |EC2| Instances with the |sdk-go|
-##########################################
+########################
+Managing |EC2| Instances
+########################
 
 .. meta::
-   :description: Use this code example to learn how to manage Amazon EC2 instances with Go.
-   :keywords: AWS SDK for Go examples, EC2 instance management
+   :description: Learn to manage Amazon EC2 instances using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, EC2 instance management
 
 
 These Go examples show you how to:
@@ -31,8 +31,8 @@ You can download complete versions of these example files from the
 
 .. _ec2-manage-instances-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 In these examples, you use a series of Go routines to perform several basic instance management operations.
 

--- a/doc_source/ec2-example-regions-availability-zones.rst
+++ b/doc_source/ec2-example-regions-availability-zones.rst
@@ -10,17 +10,15 @@
 
 .. _examples-ec2-regions-and-azs:
 
-#############################################################
-Using Regions and Availability Zones with |EC2| with |sdk-go|
-#############################################################
+###############################################
+Using Regions and Availability Zones with |EC2|
+###############################################
 
 .. meta::
-   :description: Use this code example to work with regions and Availability Zones in AWS with Go.
-   :keywords: AWS SDK for Go examples, EC2 availability zones and regions
+   :description: Work with regions and Availability Zones using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, EC2 availability zones and regions
 
-These Go examples show you how to:
-
-* Retrieve details about AWS Regions and Availability Zones.
+These Go examples show you how to retrieve details about AWS Regions and Availability Zones.
 
 An |EC2| security group acts as a virtual firewall that controls the traffic for one or
 more instances. You add rules to each security group to allow traffic to or from its
@@ -42,8 +40,8 @@ You can download complete versions of these example files from the
 
 .. _ec2-scenario-regions-and-azs:
 
-The Scenario
-============
+Scenario
+========
 
 |EC2| is hosted in multiple locations worldwide. These locations are composed of AWS Regions and Availability
 Zones. Each region is a separate geographic area with multiple, isolated locations known as Availability

--- a/doc_source/ec2-example-security-groups.rst
+++ b/doc_source/ec2-example-security-groups.rst
@@ -10,13 +10,13 @@
 
 .. _examples-ec2-work-with-security-groups:
 
-#############################################
-Working with Security Groups in |EC2| with Go
-#############################################
+#####################################
+Working with Security Groups in |EC2|
+#####################################
 
 .. meta::
-   :description: Use this Go code example to learn how to work with security groups in AWS.
-   :keywords: AWS SDK for Go examples, EC2 security groups
+   :description: Work with security groups in Amazon EC2 using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, EC2 security groups
 
 These Go examples show you how to:
 
@@ -29,8 +29,8 @@ You can download complete versions of these example files from the
 
 .. _scenario-security-groups:
 
-The Scenario
-============
+Scenario
+========
 
 An |EC2| security group acts as a virtual firewall that controls the traffic for one or
 more instances. You add rules to each security group to allow traffic to or from its

--- a/doc_source/ec2-example-working-with-key-pairs.rst
+++ b/doc_source/ec2-example-working-with-key-pairs.rst
@@ -10,13 +10,13 @@
 
 .. _examples-ec2-key-pairs:
 
-##############################################
-Working with |EC2| Key Pairs with the |sdk-go|
-##############################################
+############################
+Working with |EC2| Key Pairs
+############################
 
 .. meta::
-   :description: Use this code example to learn how to manage Amazon EC2 key pairs with Go.
-   :keywords: examples, EC2, key pairs
+   :description: Manage Amazon EC2 key pairs using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, EC2, key pairs
 
 
 These Go examples show you how to:
@@ -30,8 +30,8 @@ You can download complete versions of these example files from the
 
 .. _ec2-key-pairs-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 |EC2| uses public–key cryptography to encrypt and decrypt login information. Public–key cryptography uses a
 public key to encrypt data, then the recipient uses the private key to decrypt the data. The public and private

--- a/doc_source/iam-example-account-aliases.rst
+++ b/doc_source/iam-example-account-aliases.rst
@@ -10,21 +10,21 @@
 
 .. _examples-iam-aliases:
 
-################################################
-Managing |IAM| Account Aliases with the |sdk-go|
-################################################
+##############################
+Managing |IAM| Account Aliases
+##############################
 
 .. meta::
-   :description: Use this code example to learn how to manage IAM account aliases in Go.
-   :keywords: AWS SDK for Go examples, IAM alias
+   :description: Learn to manage IAM account aliases using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, IAM alias
 
 
 This Go example shows you how to create, list, and delete |IAM| account aliases. You can download complete versions of these example files from the :doc-examples-go:`aws-doc-sdk-examples <s3>` repository on GitHub.
 
 .. _iam-aliases-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 You can use a series of Go routines to manage aliases in |IAM|. The routines use the |sdk-go| IAM client methods that follow:
 

--- a/doc_source/iam-example-managing-access-keys.rst
+++ b/doc_source/iam-example-managing-access-keys.rst
@@ -10,21 +10,21 @@
 
 .. _examples-iam-access-keys:
 
-############################################
-Managing |IAM| Access Keys with the |sdk-go|
-############################################
+##########################
+Managing |IAM| Access Keys
+##########################
 
 .. meta::
-   :description: Use this code example to learn how to manage IAM access keys in Go.
-   :keywords: AWS SDK for Go examples, IAM access keys
+   :description: Manage IAM access keys using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, IAM access keys
 
 
 This Go example shows you how to create, modify, view, or rotate |IAM| access keys. You can download complete versions of these example files from the :doc-examples-go:`aws-doc-sdk-examples <s3>` repository on GitHub.
 
 .. _iam-access-keys-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 Users need their own access keys to make programmatic calls to the |sdk-go|. To fill this need, you can create, modify, view, or rotate access keys (access key IDs and secret access keys) for |IAM| users. By default, when you create an access key its status is Active, which means the user can use the access key for API calls.
 

--- a/doc_source/iam-example-managing-users.rst
+++ b/doc_source/iam-example-managing-users.rst
@@ -10,13 +10,13 @@
 
 .. _examples-iam-users:
 
-######################################
-Managing |IAM| Users with the |sdk-go|
-######################################
+####################
+Managing |IAM| Users
+####################
 
 .. meta::
-   :description: Use this code example to learn how to manage IAM users in Go.
-   :keywords: AWS SDK for Go examples, IAM users
+   :description: Learn to manage IAM users with this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, IAM users
 
 
 This Go example shows you how to create, update, view, and
@@ -25,8 +25,8 @@ example files from the :doc-examples-go:`aws-doc-sdk-examples <s3>` repository o
 
 .. _iam-users-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 In this example, you use a series of Go routines to manage users in |IAM|.
 The routines use the |sdk-go| IAM client methods that follow:

--- a/doc_source/iam-example-policies.rst
+++ b/doc_source/iam-example-policies.rst
@@ -10,21 +10,21 @@
 
 .. _examples-iam-policies:
 
-#############################################
-Working with |IAM| Policies with the |sdk-go|
-#############################################
+###########################
+Working with |IAM| Policies
+###########################
 
 .. meta::
-   :description: Use this code example to learn how to manage IAM policies in Go.
-   :keywords: AWS SDK for Go examples, IAM policies
+   :description: Learn to manage IAM policies using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, IAM policies
 
 
 This Go example shows you how to create, get, attach, and detach |IAM| policies. You can download complete versions of these example files from the :doc-examples-go:`aws-doc-sdk-examples <s3>` repository on GitHub.
 
 .. _iam-policies-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 You grant permissions to a user by creating a policy, which is a document that lists the actions that a user can perform and the resources those actions can affect. Any actions or resources that are not explicitly allowed are denied by default. Policies can be created and attached to users, groups of users, roles
 assumed by users, and resources.

--- a/doc_source/iam-example-server-certificates.rst
+++ b/doc_source/iam-example-server-certificates.rst
@@ -10,13 +10,13 @@
 
 .. _examples-iam-certificates:
 
-########################################################
-Working with |IAM| Server Certificates with the |sdk-go|
-########################################################
+######################################
+Working with |IAM| Server Certificates
+######################################
 
 .. meta::
-   :description: Use this code example to learn how to manage |IAM| server certificates in Go.
-   :keywords: AWS SDK for Go examples, IAM server certificates
+   :description: Learn to manage |IAM| server certificates using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, IAM server certificates
 
 This Go example shows you how to carry out basic tasks for managing server certificate HTTPS connections with the |sdk-go|.
 
@@ -24,8 +24,8 @@ You can download complete versions of these example files from the :doc-examples
 
 .. _iam-certificates-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 To enable HTTPS connections to your website or application on AWS, you need an SSL/TLS server certificate. To use a certificate that you obtained from an external provider with your website or application on AWS, you must upload the certificate to |IAM| or import it into AWS Certificate Manager.
 

--- a/doc_source/kms-example-create-key.rst
+++ b/doc_source/kms-example-create-key.rst
@@ -10,9 +10,14 @@
 
 .. _kms-example-create-key:
 
-##############
-Creating a CMK
-##############
+###########################
+Creating a CMK in |KMSlong|
+###########################
+
+.. meta::
+    :description:
+        Create a CMK data in AWS KMS using this AWS SDK for Go code example.
+    :keywords: AWS SDK for Go code examples, KMS
 
 The following example uses the |sdk-go| `CreateKey <http://docs.aws.amazon.com/sdk-for-go/api/service/kms/#KMS.CreateKey>`_
 method,

--- a/doc_source/kms-example-decrypt-blob.rst
+++ b/doc_source/kms-example-decrypt-blob.rst
@@ -10,11 +10,16 @@
 
 .. _kms-example-decrypt-blob:
 
-######################
-Decrypting a Data Blob
-######################
+###################################
+Decrypting a Data Blob in |KMSlong|
+###################################
 
-The following example uses the |sdk-go| 
+.. meta::
+    :description:
+        Decrypt a data blob in AWS KMS using this AWS SDK for Go code example.
+    :keywords: AWS SDK for Go code examples, KMS
+
+The following example uses the |sdk-go|
 `Decrypt <http://docs.aws.amazon.com/sdk-for-go/api/service/kms/#KMS.Decrypt>`_ method,
 which implements the
 `Decrypt <http://docs.aws.amazon.com/kms/latest/APIReference/API_Decrypt.html>`_ operation,

--- a/doc_source/kms-example-encrypt-data.rst
+++ b/doc_source/kms-example-encrypt-data.rst
@@ -10,11 +10,16 @@
 
 .. _kms-example-encrypt-data:
 
-###############
-Encrypting Data
-###############
+##############################
+Encrypting Data with |KMSlong|
+##############################
 
-The following example uses the |sdk-go| 
+.. meta::
+    :description:
+        Encrypt data in AWS KMS using this AWS SDK for Go code example.
+    :keywords: AWS SDK for Go code examples, KMS
+
+The following example uses the |sdk-go|
 `Encrypt <http://docs.aws.amazon.com/sdk-for-go/api/service/kms/#KMS.Encrypt>`_ method,
 which implements the
 `Encrypt <http://docs.aws.amazon.com/kms/latest/APIReference/API_Encrypt.html>`_ operation,

--- a/doc_source/kms-example-re-encrypt-data.rst
+++ b/doc_source/kms-example-re-encrypt-data.rst
@@ -10,11 +10,16 @@
 
 .. _kms-example-re-encrypt-data:
 
-#########################
-Re-encrypting a Data Blob
-#########################
+######################################
+Re-encrypting a Data Blob in |KMSlong|
+######################################
 
-The following example uses the |sdk-go| 
+.. meta::
+    :description:
+        Re-encrypt data in AWS KMS using this AWS SDK for Go code example.
+    :keywords: AWS SDK for Go code examples, KMS
+
+The following example uses the |sdk-go|
 `ReEncrypt <http://docs.aws.amazon.com/sdk-for-go/api/service/kms/#KMS.ReEncrypt>`_ method,
 which implements the
 `ReEncrypt <http://docs.aws.amazon.com/kms/latest/APIReference/API_ReEncrypt.html>`_ operation,

--- a/doc_source/lambda-go-example-configure-function-for-notification.rst
+++ b/doc_source/lambda-go-example-configure-function-for-notification.rst
@@ -10,9 +10,14 @@
 
 .. _lambda-go-example-configure-function-for-notification:
 
-#######################################################################
-Configuring a |LAM| Function to Receive Notifications with the |sdk-go|
-#######################################################################
+#####################################################
+Configuring a |LAM| Function to Receive Notifications
+#####################################################
+
+.. meta::
+    :description:
+        Configure AWS Lambda functions using this AWS SDK for Go code example.
+    :keywords: AWS SDK for Go code examples, Lambda
 
 The following example configures the |LAM| function :code:`functionName`
 to accept notifications from the resource with the ARN :code:`sourceArn`.

--- a/doc_source/lambda-go-example-create-function.rst
+++ b/doc_source/lambda-go-example-create-function.rst
@@ -10,9 +10,14 @@
 
 .. _lambda-go-example-create-function:
 
-###########################################
-Creating a |LAM| Function with the |sdk-go|
-###########################################
+#########################
+Creating a |LAM| Function
+#########################
+
+.. meta::
+    :description:
+        Create AWS Lambda functions using this AWS SDK for Go code example.
+    :keywords: AWS SDK for Go code examples, Lambda
 
 The following example creates the |LAM| function :code:`functionName`
 in the :code:`us-west-2` region using the following values:

--- a/doc_source/lambda-go-example-run-function.rst
+++ b/doc_source/lambda-go-example-run-function.rst
@@ -10,9 +10,14 @@
 
 .. _lambda-go-example-run-function:
 
-##########################################
-Running a |LAM| Function with the |sdk-go|
-##########################################
+########################
+Running a |LAM| Function
+########################
+
+.. meta::
+    :description:
+        Run AWS Lambda functions using this AWS SDK for Go code example.
+    :keywords: AWS SDK for Go code examples, Lambda
 
 The following example rus the |LAM| function :code:`MyGetitemsFunction` in the :code:`us-west-2` region.
 This Node.js function returns a list of items from a database. The input JSON looks like the following.

--- a/doc_source/lambda-go-example-show-functions.rst
+++ b/doc_source/lambda-go-example-show-functions.rst
@@ -10,9 +10,14 @@
 
 .. _lambda-go-example-show-functions:
 
-##################################################################
-Displaying Information about All |LAM| Functions with the |sdk-go|
-##################################################################
+################################################
+Displaying Information about All |LAM| Functions
+################################################
+
+.. meta::
+    :description:
+        Display information about AWS Lambda functions using this AWS SDK for Go code example.
+    :keywords: AWS SDK for Go code examples, Lambda
 
 The following example displays the names and descriptions of the
 |LAM| functions in the :code:`us-west-2` region.

--- a/doc_source/s3-example-basic-bucket-operations.rst
+++ b/doc_source/s3-example-basic-bucket-operations.rst
@@ -10,13 +10,13 @@
 
 .. _s3-examples-bucket-ops:
 
-##############################################
-Basic |S3| Bucket Operations with the |sdk-go|
-##############################################
+#######################################
+Performing Basic |S3| Bucket Operations
+#######################################
 
 .. meta::
-   :description: Use S3 code examples to create and use |S3| buckets in Go applications.
-   :keywords: AWS SDK for Go examples, |S3|, list buckets, create bucket,
+   :description: Create and use Amazon S3 buckets using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, S3, list buckets, create bucket,
               list bucket items, add file to bucket, download file from
               bucket, copy bucket item to another bucket, delete bucket
               item, delete all bucket items, restore bucket item,
@@ -42,8 +42,8 @@ versions of these example files from the
 
 .. _s3-examples-bucket-ops-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 In these examples, a series of Go routines are used to perform operations
 on your |S3| buckets.

--- a/doc_source/s3-example-bucket-acls.rst
+++ b/doc_source/s3-example-bucket-acls.rst
@@ -10,14 +10,13 @@
 
 .. _s3-examples-bucket-acls:
 
-#############################################
-Working with |S3| Bucket ACLs in the |sdk-go|
-#############################################
+#############################
+Working with |S3| Bucket ACLs
+#############################
 
 .. meta::
-   :description: Use S3 code examples to manage |S3| bucket ACLs in
-                 Go applications.
-   :keywords: AWS SDK for Go examples, |S3|, ACL, permissions
+   :description: Manage Amazon S3 bucket ACLs in using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, S3, ACL, permissions
 
 The following examples use |sdk-go| functions to:
 
@@ -32,8 +31,8 @@ versions of these example files from the
 
 .. _s3-examples-bucket-acls-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 In these examples, a series of Go routines are used to manage ACLs
 on your |S3| buckets.

--- a/doc_source/s3-example-bucket-policy.rst
+++ b/doc_source/s3-example-bucket-policy.rst
@@ -10,12 +10,12 @@
 
 .. _examples-s3-bucket-policies:
 
-###################################################
-Working with |S3| Bucket Policies with the |sdk-go|
-###################################################
+#################################
+Working with |S3| Bucket Policies
+#################################
 
 .. meta::
-   :description: Use this code example to learn how to work with Amazon S3 bucket policies.
+   :description: Work with Amazon S3 bucket policies using this AWS SDK for Go code example.
    :keywords: AWS SDK for Go examples, S3, policy, ACL, permissions
 
 
@@ -25,8 +25,8 @@ complete versions of these example files from the
 
 .. _s3-bucket-policies-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 In this example, you use a series of Go routines to retrieve or set a bucket policy on an
 |S3| bucket. The routines use the |sdk-go| to configure policy for a selected |S3| bucket using

--- a/doc_source/s3-example-cors.rst
+++ b/doc_source/s3-example-cors.rst
@@ -10,13 +10,14 @@
 
 .. _examples-s3-cors:
 
-####################################################
-Working with |S3| CORS Permissions with the |sdk-go|
-####################################################
+##################################
+Working with |S3| CORS Permissions
+##################################
 
 .. meta::
-   :description: Use this code example to learn how to work with cross origin resource sharing (CORS) an Amazon S3 bucket.
-   :keywords: AWS SDK for Go examples, S3, cross origin resource sharing, CORS
+   :description: Learn to work with cross-origin resource sharing (CORS) for an Amazon S3 bucket using
+   this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, S3, cross origin resource sharing, CORS
 
 
 This |sdk-go| example shows you how to list |S3| buckets and configure
@@ -25,8 +26,8 @@ CORS and bucket logging. You can download complete versions of these example fil
 
 .. _s3-cors-scenario:
 
-The Scenario
-================
+Scenario
+========
 
 In this example, a series of Go routines are used to list your |S3| buckets and to configure
 CORS and bucket logging. The routines use the |sdk-go| to configure a selected

--- a/doc_source/s3-example-presigned-urls.rst
+++ b/doc_source/s3-example-presigned-urls.rst
@@ -10,13 +10,13 @@
 
 .. _examples-s3-presigned-urls:
 
-###########################################################
-Creating Pre-Signed URLs for |S3| Buckets with the |sdk-go|
-###########################################################
+#########################################
+Creating Pre-Signed URLs for |S3| Buckets
+#########################################
 
 .. meta::
-   :description: Use S3 code examples to create presigned URLS to S3 buckets in your Go applications.
-   :keywords: examples, S3, create, presigned, URLs
+   :description: Create presigned URLS to Amazon S3 buckets using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, S3, create, presigned, URLs
 
 
 This Go example shows you how to obtain a pre-signed URL for an |S3| bucket. You can download complete
@@ -24,8 +24,8 @@ versions of these example files from the :doc-examples-go:`aws-doc-sdk-examples 
 
 .. _s3-pre-signed-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 In this example, a series of Go routines are used to obtain a pre-signed URL for
 an |S3| bucket using either GetObject or a PUT operation. A pre-signed URL allows you

--- a/doc_source/s3-example-static-web-host.rst
+++ b/doc_source/s3-example-static-web-host.rst
@@ -10,13 +10,13 @@
 
 .. _examples-s3-website:
 
-###########################################################
-Using an |S3| Bucket as a Static Web Host with the |sdk-go|
-###########################################################
+#########################################
+Using an |S3| Bucket as a Static Web Host
+#########################################
 
 .. meta::
-   :description: Use S3 code examples to learn how to set up an Amazon S3 bucket as a static web host in your own Go applications.
-   :keywords: AWS SDK for Go examples, S3 static web host
+   :description: Set up an Amazon S3 bucket as a static web host using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, S3 static web host
 
 
 This |sdk-go| example shows you how to configure an |S3| bucket to act as a static web host. You can download
@@ -24,8 +24,8 @@ complete versions of these example files from the :doc-examples-go:`aws-doc-sdk-
 
 .. _s3-website-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 In this example, you use a series of Go routines to configure any of your
 buckets to act as a static web host. The routines use the |sdk-go| to configure a selected |S3|

--- a/doc_source/sqs-example-create-queue.rst
+++ b/doc_source/sqs-example-create-queue.rst
@@ -10,13 +10,13 @@
 
 .. _examples-sqs-using-queues:
 
-####################################
-Using |SQS| Queues with the |sdk-go|
-####################################
+##################
+Using |SQS| Queues
+##################
 
 .. meta::
-   :description: Use these code examples to learn how to work with Amazon SQS queues.
-   :keywords: AWS SDK for Go examples, SQS, create queue
+   :description: Learn to work with Amazon SQS queues using this AWS SDK for Go.
+   :keywords: AWS SDK for Go code examples, SQS, create queue
 
 
 These |sdk-go| examples show you how to:
@@ -31,8 +31,8 @@ You can download complete versions of these example files from the
 
 .. _sqs-create-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 These examples demonstrate how to work with |SQS| queues.
 

--- a/doc_source/sqs-example-dead-letter-queues.rst
+++ b/doc_source/sqs-example-dead-letter-queues.rst
@@ -10,13 +10,13 @@
 
 .. _examples-sqs-using-dead-letter-queues:
 
-###################################################
-Using Dead Letter Queues in |SQS| with the |sdk-go|
-###################################################
+#################################
+Using Dead Letter Queues in |SQS|
+#################################
 
 .. meta::
-   :description: Use these code examples to use an Amazon SQS queue to receive and hold messages.
-   :keywords: AWS SDK for Go examples, SQS, create queue
+   :description: Use an Amazon SQS queue to receive and hold messages with this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, SQS, create queue
 
 
 This |sdk-go| example shows you how to configure source |SQS| queues that send messages to
@@ -27,8 +27,8 @@ You can download complete versions of these example files from the
 
 .. _sqs-dead-letter-queue-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 A dead letter queue is one that other (source) queues can target for messages that can't be
 processed successfully. You can set aside and isolate these messages in the dead letter queue

--- a/doc_source/sqs-example-enable-long-polling.rst
+++ b/doc_source/sqs-example-enable-long-polling.rst
@@ -10,13 +10,13 @@
 
 .. _examples-sqs-long-polling:
 
-#######################################################
-Enabling Long Polling in |SQS| Queues with the |sdk-go|
-#######################################################
+#####################################
+Enabling Long Polling in |SQS| Queues
+#####################################
 
 .. meta::
-   :description: Use these code examples to learn enable long polling with Amazon SQS queues.
-   :keywords: AWS SDK for Go examples, SQS, create queue
+   :description: Enable long polling with Amazon SQS queues using this AWS SDK code example.
+   :keywords: AWS SDK for Go code examples, SQS, create queue
 
 
 These |sdk-go| examples show you how to:
@@ -30,8 +30,8 @@ You can download complete versions of these example files from the
 
 .. _sqs-long-polling-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 Long polling reduces the number of empty responses by allowing |SQS|
 to wait a specified time for a message to become available in the queue before sending a response.

--- a/doc_source/sqs-example-managing-visibility-timeout.rst
+++ b/doc_source/sqs-example-managing-visibility-timeout.rst
@@ -10,13 +10,13 @@
 
 .. _examples-sqs-managing-visibility:
 
-#############################################################
-Managing Visibility Timeout in |SQS| Queues with the |sdk-go|
-#############################################################
+###########################################
+Managing Visibility Timeout in |SQS| Queues
+###########################################
 
 .. meta::
-   :description: Use these Go examples to learn how to manage visibility timeout with Amazon SQS queues.
-   :keywords: AWS SDK for Go examples, creating SQS queues
+   :description: Manage visibility timeout with Amazon SQS queues using this AWS SDK for Go code exammple.
+   :keywords: AWS SDK for Go code examples, creating SQS queues
 
 
 This |sdk-go| example shows you how to:
@@ -28,8 +28,8 @@ You can download complete versions of these example files from the
 
 .. _sqs-visibility-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 This example manages visibility timeout with |SQS| queues. It uses these methods of the
 |SQS| client class:

--- a/doc_source/sqs-example-receive-message.rst
+++ b/doc_source/sqs-example-receive-message.rst
@@ -10,12 +10,12 @@
 
 .. _examples-sqs-receive-message:
 
-#########################################################
-Sending and Receiving Messages in |SQS| with the |sdk-go|
-#########################################################
+#######################################
+Sending and Receiving Messages in |SQS|
+#######################################
 
 .. meta::
-   :description: Use this code example to learn how to send or receive a message from an Amazon SQS queue.
+   :description: Send or receive a message from an Amazon SQS queue using this AWS SDK for Go code example.
    :keywords: AWS SDK for Go examples, SQS queues
 
 These |sdk-go| examples show you how to:

--- a/doc_source/sqs-example-set-attributes.rst
+++ b/doc_source/sqs-example-set-attributes.rst
@@ -10,13 +10,13 @@
 
 .. _examples-sqs-set-attributes:
 
-######################################################
-Setting Attributes on an |SQS| Queue with the |sdk-go|
-######################################################
+####################################
+Setting Attributes on an |SQS| Queue
+####################################
 
 .. meta::
-   :description: Use this code example to learn how to set attributes on an Amazon SQS queue.
-   :keywords: AWS SDK for Go examples, SQS, create queue
+   :description: Set attributes on an Amazon SQS queue using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, SQS, create queue
 
 This Go example shows you how to set attributes on an existing |SQS| queue.
 
@@ -25,8 +25,8 @@ You can download complete versions of these example files from the
 
 .. _sqs-attributes-scenario:
 
-The Scenario
-============
+Scenario
+========
 
 This example updates an existing |SQS| queue to use long polling.
 

--- a/doc_source/using-cb-with-go-sdk.rst
+++ b/doc_source/using-cb-with-go-sdk.rst
@@ -16,9 +16,10 @@
 
 .. meta::
    :description: Use CodeBuild code examples to write your own Go applications.
-   :keywords: AWS SDK Go examples, |ACBlong|
+   :keywords: AWS SDK for Go code examples, |ACBlong|
 
-The |sdk-go| examples can integrate |ACBlong| into your applications.
+|ACB| is a fully managed build service that compiles source code, runs tests, and produces
+software packages that are ready to deploy. The |sdk-go| examples can integrate |ACBlong| into your applications.
 The examples assume you have already set up and configured the SDK
 (that is, you've imported all required packages and set your credentials
 and region).
@@ -30,7 +31,7 @@ You can download complete versions of these example files from the
 .. toctree::
    :maxdepth: 1
 
-   Getting Information about All Projects <cb-example-list-projects>
-   Building a Project <cb-example-build-project>
-   Listing your Project Builds <cb-example-list-builds>
+   cb-example-list-projects
+   cb-example-build-project
+   cb-example-list-builds
 

--- a/doc_source/using-cloudwatch-with-go-sdk.rst
+++ b/doc_source/using-cloudwatch-with-go-sdk.rst
@@ -16,7 +16,7 @@
 
 .. meta::
    :description: Use Amazon CloudWatch code examples to write your Go applications.
-   :keywords: examples, CloudWatch
+   :keywords: AWS SDK for Go code examples, CloudWatch
 
 
 |CWlong| is a web service that monitors your AWS resources and the applications
@@ -36,10 +36,10 @@ You can download complete versions of these example files from the
    :titlesonly:
    :maxdepth: 1
 
-   Describing CloudWatch Alarms <cw-example-describing-alarms>
-   Using Alarms and Alarm Actions with CloudWatch <cw-example-using-alarm-actions>
-   Getting Metrics from CloudWatch <cw-example-getting-metrics>
-   Sending Events to Amazon CloudWatch Events <cw-example-sending-events>
+   cw-example-describing-alarms
+   cw-example-using-alarm-actions
+   cw-example-getting-metrics
+   cw-example-sending-events
 
 
 

--- a/doc_source/using-dynamodb-with-go-sdk.rst
+++ b/doc_source/using-dynamodb-with-go-sdk.rst
@@ -18,7 +18,8 @@
    :description: Use DynamoDB code examples to write your own Go applications.
    :keywords: AWS SDK for Go examples, DynamoDB
 
-The |sdk-go| examples can integrate |DDBlong| into your Go applications.
+|DDBlong| is a fully managed NoSQL database service that provides fast and predictable performance with
+seamless scalability. The |sdk-go| examples can integrate |DDBlong| into your Go applications.
 The examples assume you have already set up and configured the SDK (that
 is, you have imported all required packages and set your credentials and region). For more information, see :doc:`setting-up` and :doc:`configuring-sdk`.
 

--- a/doc_source/using-ec2-with-go-sdk.rst
+++ b/doc_source/using-ec2-with-go-sdk.rst
@@ -18,7 +18,8 @@
    :description: Use Amazon EC2 code examples to write your own Go applications.
    :keywords: examples, EC2
 
-The |sdk-go| examples can integrate |EC2| into your Go applications.
+|EC2long| (|EC2|) is a web service that provides resizeable computing capacity |mdash| literally servers
+in Amazon's data centers |mdash| that you use to build and host your software systems. The |sdk-go| examples can integrate |EC2| into your Go applications.
 The examples assume you have already set up and configured the SDK (that
 is, you have imported all required packages and set your credentials and region). For more information, see :doc:`setting-up` and :doc:`configuring-sdk`.
 
@@ -30,12 +31,12 @@ You can download complete versions of these example files from the
    :maxdepth: 1
 
 
-   Creating Amazon EC2 Instances with Tags or without Block Devices <ec2-example-create-images>
-   Managing Amazon EC2 Instances <ec2-example-manage-instances>
-   Working with Amazon EC2 Key Pairs <ec2-example-working-with-key-pairs>
-   Using Regions and Availability Zones with Amazon EC2 <ec2-example-regions-availability-zones>
-   Working with Security Groups in Amazon EC2 <ec2-example-security-groups>
-   Using Elastic IP Addresses in Amazon EC2 <ec2-example-elastic-ip-addresses>
+   ec2-example-create-images
+   ec2-example-manage-instances
+   ec2-example-working-with-key-pairs
+   ec2-example-regions-availability-zones
+   ec2-example-security-groups
+   ec2-example-elastic-ip-addresses
 
 
 

--- a/doc_source/using-glacier-with-go-sdk.rst
+++ b/doc_source/using-glacier-with-go-sdk.rst
@@ -16,9 +16,10 @@
 
 .. meta::
    :description: Use Amazon Glacier code examples to write your own Go applications.
-   :keywords: AWS SDK for go examples, Glacier
+   :keywords: AWS SDK for Go code examples, Amazon Glacier
 
-The |sdk-go| examples can integrate |GLlong| into your applications. The examples assume you have already set up and configured the SDK (that is, you've imported all required packages and set your credentials and region). For more information, see :doc:`setting-up` and :doc:`configuring-sdk`.
+|GLlong| is a secure, durable, and extremely low-cost cloud storage service for data archiving and long-term
+backup. The |sdk-go| examples can integrate |GLlong| into your applications. The examples assume you have already set up and configured the SDK (that is, you've imported all required packages and set your credentials and region). For more information, see :doc:`setting-up` and :doc:`configuring-sdk`.
 
 You can download complete versions of these example files from the :doc-examples-go:`aws-doc-sdk-examples <glacier>` repository on GitHub.
 

--- a/doc_source/using-iam-with-go-sdk.rst
+++ b/doc_source/using-iam-with-go-sdk.rst
@@ -34,8 +34,8 @@ You can download complete versions of these example files from the
    :titlesonly:
    :maxdepth: 1
 
-   Managing IAM Users <iam-example-managing-users>
-   Managing IAM Access Keys <iam-example-managing-access-keys>
-   Managing IAM Account Aliases <iam-example-account-aliases>
-   Working with IAM Policies <iam-example-policies>
-   Working with IAM Server Certificates <iam-example-server-certificates>
+   iam-example-managing-users
+   iam-example-managing-access-keys
+   iam-example-account-aliases
+   iam-example-policies
+   iam-example-server-certificates

--- a/doc_source/using-lambda-with-go-sdk.rst
+++ b/doc_source/using-lambda-with-go-sdk.rst
@@ -12,7 +12,13 @@
 |LAMlong| Examples Using the |sdk-go|
 #####################################
 
-You can use the following examples to access |LAMlong| (|LAM|) using the |sdk-go|. For
+.. meta::
+    :description:
+        AWS SDK for Go code examples for AWS Lambda.
+    :keywords:
+
+|LAMlong| (|LAM|) is a zero-administration compute platform for backend web developers that runs your
+code for you in the AWS Cloud, and provides you with a fine-grained pricing structure. You can use the following examples to access |LAMlong| (|LAM|) using the |sdk-go|. For
 more information about |LAM|, see the `Lambda documentation <http://aws.amazon.com/documentation/lambda/>`_.
 
 You can download complete versions of these example files from the
@@ -21,7 +27,7 @@ You can download complete versions of these example files from the
 .. toctree::
    :maxdepth: 2
 
-   Displaying Information about All Lambda Functions <lambda-go-example-show-functions>
-   Creating a Lambda Function <lambda-go-example-create-function>
-   Running a Lambda Function <lambda-go-example-run-function>
-   Configuring a Lambda Function to Receive Notifications <lambda-go-example-configure-function-for-notification>
+   lambda-go-example-show-functions
+   lambda-go-example-create-function
+   lambda-go-example-run-function
+   lambda-go-example-configure-function-for-notification

--- a/doc_source/using-requests-with-go-sdk.rst
+++ b/doc_source/using-requests-with-go-sdk.rst
@@ -14,8 +14,8 @@
 #########################
 
 .. meta::
-   :description: Learn how to work with requests in your Go applications.
-   :keywords: examples, requests
+   :description: Learn how to work with requests in Go applications using this AWS SDK for Go code example.
+   :keywords: AWS SDK for Go code examples, requests
 
 
 

--- a/doc_source/using-s3-with-go-sdk.rst
+++ b/doc_source/using-s3-with-go-sdk.rst
@@ -16,9 +16,9 @@
 
 .. meta::
    :description: Use S3 code examples to write your own Go applications.
-   :keywords: AWS SDK Go examples, Amazon S3
+   :keywords: AWS SDK Go code examples, Amazon S3
 
-The |sdk-go| examples can integrate |S3| into your applications. The examples assume you have already set up and configured the SDK (that is, you've imported all required packages and set your credentials and region). For more information, see :doc:`setting-up` and :doc:`configuring-sdk`.
+|S3long| (|S3|) is storage for the internet. The |sdk-go| examples can integrate |S3| into your applications. The examples assume you have already set up and configured the SDK (that is, you've imported all required packages and set your credentials and region). For more information, see :doc:`setting-up` and :doc:`configuring-sdk`.
 
 You can download complete versions of these example files from the :doc-examples-go:`aws-doc-sdk-examples <s3>` repository on GitHub.
 
@@ -26,9 +26,9 @@ You can download complete versions of these example files from the :doc-examples
    :titlesonly:
    :maxdepth: 1
 
-   Basic Amazon S3 Bucket Operations <s3-example-basic-bucket-operations>
-   Creating Presigned URLs for Amazon S3 Buckets <s3-example-presigned-urls>
-   Using an Amazon S3 Bucket as a Static Web Host <s3-example-static-web-host>
-   Working with Amazon S3 CORS Permissions <s3-example-cors>
-   Working with Amazon S3 Bucket Policies <s3-example-bucket-policy>
-   Working with Amazon S3 Bucket ACLs <s3-example-bucket-acls>
+   s3-example-basic-bucket-operations
+   s3-example-presigned-urls
+   s3-example-static-web-host
+   s3-example-cors
+   s3-example-bucket-policy
+   s3-example-bucket-acls

--- a/doc_source/using-sqs-with-go-sdk.rst
+++ b/doc_source/using-sqs-with-go-sdk.rst
@@ -16,9 +16,10 @@
 
 .. meta::
    :description: Use Amazon SQS code examples to write your own Go applications.
-   :keywords: AWS SDK for Go examples, SQS
+   :keywords: AWS SDK for Go code examples, SQS
 
-The |sdk-go| examples can integrate |SQS| into your applications.
+|SQSlong| (|SQS|) is a fully managed message queuing service that makes it easy to decouple and scale microservices,
+distributed systems, and serverless applications. The |sdk-go| examples can integrate |SQS| into your applications.
 The examples assume you have already set up and configured the SDK (that
 is, you've imported all required packages and set your credentials and region). For more information, see :doc:`setting-up` and :doc:`configuring-sdk`.
 
@@ -29,12 +30,12 @@ You can download complete versions of these example files from the
    :titlesonly:
    :maxdepth: 1
 
-   Using |SQS| queues <sqs-example-create-queue>
-   Sending and Receiving Messages in |SQS| <sqs-example-receive-message>
-   Managing Visibility Timeout in |SQS| Queues <sqs-example-managing-visibility-timeout>
-   Enabling Long Polling in |SQS| Queues <sqs-example-enable-long-polling>
-   Using Dead Letter Queues in |SQS| <sqs-example-dead-letter-queues>
-   Setting Attributes on an |SQS| <sqs-example-set-attributes>
+   sqs-example-create-queue
+   sqs-example-receive-message
+   sqs-example-managing-visibility-timeout
+   sqs-example-enable-long-polling
+   sqs-example-dead-letter-queues
+   sqs-example-set-attributes
 
 
 

--- a/doc_source/welcome.rst
+++ b/doc_source/welcome.rst
@@ -8,12 +8,13 @@
    either express or implied. See the License for the specific language governing permissions and
    limitations under the License.
 
-###########
-|sdk-go-dg|
-###########
+##############################
+AWS SDK for Go Developer Guide
+##############################
 
 .. meta::
-   :description: Use the |sdk-go| to build Go applications that use AWS services.
+   :description: Use the AWS SDK for Go to build Go applications that use AWS services.
+   :keywords: AWS SDK for Go, code examples
 
 The |sdk-go| provides APIs and utilities that developers can use
 to build Go applications that use AWS services, such as |EC2long| (|EC2|) and


### PR DESCRIPTION
Standardizing meta descriptions for code examples, making sure service name is included in code example topic titles.