### PR TITLE
Fixed poorly coded DynamoDB GetItem code example

### DIFF
--- a/doc_source/dynamo-example-read-table-item.rst
+++ b/doc_source/dynamo-example-read-table-item.rst
@@ -56,8 +56,8 @@ Otherwise, display information about the item.
    :dedent: 4
    :language: go
 
-Unmarshall the return value and if the title is not empty,
-indicating we got the item,
+If an item was returned,
+unmarshall the return value and
 display the year, title, plot, and rating.
 
 .. literalinclude:: dynamodb.go.read_item.unmarshall.txt


### PR DESCRIPTION
*Issue #, if available:*
Go code example was testing the value of a returned field against an empty string.

*Description of changes:*
Test the returned item against nil.

Don't merge until https://github.com/awsdocs/aws-doc-sdk-examples/pull/1293 has been merged and that package built to public.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
