### PR TITLE
Update dynamo-example-load-table-items-from-json.rst

### DIFF
--- a/doc_source/dynamo-example-load-table-items-from-json.rst
+++ b/doc_source/dynamo-example-load-table-items-from-json.rst
@@ -66,5 +66,5 @@ and print out the title and year of the movie added to the table.
 See the `complete example
 <https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/go/example_code/dynamodb/DynamoDBLoadItems.go>`_
 and a `sample JSON file 
-<https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/go/example_code/dynamodb/movie_data.json>`_
+<https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/go/example_code/dynamodb/.movie_data.json>`_
 on GitHub.


### PR DESCRIPTION
Updating url due to changes in https://github.com/awsdocs/aws-doc-sdk-examples/commit/7fbc4963cdc90c71a2ac6e73301a956a7867b435

*Issue #, if available:*

*Description of changes:*

Updating dynamo-example-load-table-items-from-json.rst because url to JSON from example gives 404

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
