### PR TITLE
Adjust snippet clipping in S3 Glacier example

### DIFF
--- a/doc_source/using-glacier-with-go-sdk.rst
+++ b/doc_source/using-glacier-with-go-sdk.rst
@@ -49,7 +49,7 @@ The following example uses the |GLlong| :sdk-go-api-deep:`CreateVault <service/g
 operation to create a vault named ``YOUR_VAULT_NAME``.
 
 .. literalinclude:: example_code/glacier/create_vault.go
-   :dedent: 4
+   :dedent: 0
    :lines: 15-
 
 
@@ -62,5 +62,5 @@ single reader object as an entire archive. The |sdk-go| automatically computes t
 checksum for the data to be uploaded.
 
 .. literalinclude:: example_code/glacier/upload_archive.go
-   :dedent: 4
+   :dedent: 0
    :lines: 15-


### PR DESCRIPTION
~~*Issue #, if available:*~~ 
No open issues found.

*Description of changes:*

Dedent the code snippet to avoid clipping in [Glacier example](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/using-glacier-with-go-sdk.html):

![image](https://user-images.githubusercontent.com/17013462/132199517-06d7abc8-9a28-41cb-8537-53d8d684af34.png)

Matching closest file that includes full file as snippet rather than pieces: https://github.com/awsdocs/aws-go-developer-guide/blob/master/doc_source/kms-example-create-key.rst

From briefly looking over all snippets in the doc, I believe this is the only full file snippet with this issue. However, there are other clipping errors such as in this file where the `import` section is clipped and `func ` is missing on [CloudWatch Disable Actions On An Alarm](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/cw-example-using-alarm-actions.html#disable-actions-on-an-alarm).

I have run `python build_docs.py singlehtml` but unable to completely verify changes locally since the output looked significantly different than current docs. I opted to make a smaller change that exactly matched similar files. I can file an issue with how the doc build failed if desired but all snippets were all off by ~15 lines after the script successfully ran (with warnings).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Thanks for considering this change! I'm not sure if this repository or SDK is still active but do plan to test and use this. README seems to suggest this repo is still used.
