### PR TITLE
Update instruction for configuring SDK for TLS 1.3.

### DIFF
--- a/doc_source/tls.md
+++ b/doc_source/tls.md
@@ -1,17 +1,17 @@
-# Enforcing TLS Version 1\.2 in AWS SDK for Go<a name="tls"></a>
+# Enforcing TLS Version 1\.3 in AWS SDK for Go<a name="tls"></a>
 
-To add increased security when communicating with AWS services, you should configure your client to use TLS 1\.2 or later\.
+To add increased security when communicating with AWS services, you should configure your client to use TLS 1\.3 or later\.
 
 ## How do I set my TLS version?<a name="how-do-i-set-my-tls-version"></a>
 
-You can set the TLS version to 1\.2 using the following code\.
+You can set the TLS version to 1\.3 using the following code\.
 
-1. Create a custom HTTP transport to require a minimum version of TLS 1\.2
+1. Create a custom HTTP transport to require a minimum version of TLS 1\.3
 
    ```
    tr := &http.Transport{
        TLSClientConfig: &tls.Config{
-           MinVersion: tls.VersionTLS12,
+           MinVersion: tls.VersionTLS13,
        },
    }
    ```
@@ -64,7 +64,7 @@ You can set the TLS version to 1\.2 using the following code\.
 1. Confirm your TLS version by calling *GetTLSVersion*\.
 
    ```
-   if tr, ok := s3Client.Config.HTTPClient.Transport.(*http.Transport); ok {
+   if tr, ok := sess.Config.HTTPClient.Transport.(*http.Transport); ok {
        log.Printf("Client uses %v", GetTLSVersion(tr))
    }
    ```


### PR DESCRIPTION
Updates the SDK's instructions for how to configure the SDK to use a minimum of TLS 1.3

